### PR TITLE
docker-machine integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM ansible/ubuntu14.04-ansible:stable
 MAINTAINER gimoh <gimoh@bitmessage.ch>
 
 RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get install -qy \
-    git python-dev python-pip curl
+    git python-dev python-pip
 RUN pip install --upgrade pip
 RUN pip install Fabric
 RUN install -d -o root -g root -m 700 /root/.ssh

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM ansible/ubuntu14.04-ansible:stable
 MAINTAINER gimoh <gimoh@bitmessage.ch>
 
 RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get install -qy \
-    git python-dev python-pip
+    git python-dev python-pip curl
 RUN pip install --upgrade pip
 RUN pip install Fabric
 RUN install -d -o root -g root -m 700 /root/.ssh
@@ -27,6 +27,9 @@ RUN mkdir /etc/devops-utils
 ADD . /opt/devops-utils
 RUN cd /opt/devops-utils && pip install . && \
     cp -r init_plugins runner_plugins /etc/devops-utils/
+ADD ["https://github.com/docker/machine/releases/download/v0.3.0/docker-machine_linux-amd64", \
+     "/usr/local/bin/docker-machine"]
+RUN chmod +x /usr/local/bin/docker-machine
 
 WORKDIR /opt/devops-utils
 ENTRYPOINT ["/usr/bin/ssh-agent", "/usr/local/bin/docker-init"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,14 +21,14 @@ MAINTAINER gimoh <gimoh@bitmessage.ch>
 RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get install -qy \
     git python-dev python-pip
 RUN pip install --upgrade pip
+ADD ["https://github.com/docker/machine/releases/download/v0.3.0/docker-machine_linux-amd64", \
+     "/usr/local/bin/docker-machine"]
 RUN pip install Fabric
 RUN install -d -o root -g root -m 700 /root/.ssh
 RUN mkdir /etc/devops-utils
 ADD . /opt/devops-utils
 RUN cd /opt/devops-utils && pip install . && \
     cp -r init_plugins runner_plugins /etc/devops-utils/
-ADD ["https://github.com/docker/machine/releases/download/v0.3.0/docker-machine_linux-amd64", \
-     "/usr/local/bin/docker-machine"]
 RUN chmod +x /usr/local/bin/docker-machine
 ENV MACHINE_STORAGE_PATH=/opt/devops-utils/docker-machine
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,17 +21,19 @@ MAINTAINER gimoh <gimoh@bitmessage.ch>
 RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get install -qy \
     git python-dev python-pip
 RUN pip install --upgrade pip
+
+# docker-machine installation
 ADD ["https://github.com/docker/machine/releases/download/v0.3.0/docker-machine_linux-amd64", \
      "/usr/local/bin/docker-machine"]
+RUN chmod +x /usr/local/bin/docker-machine
+ENV MACHINE_STORAGE_PATH=/opt/app/.docker/machine
+
 RUN pip install Fabric
 RUN install -d -o root -g root -m 700 /root/.ssh
 RUN mkdir /etc/devops-utils
 ADD . /opt/devops-utils
 RUN cd /opt/devops-utils && pip install . && \
     cp -r init_plugins runner_plugins /etc/devops-utils/
-RUN chmod +x /usr/local/bin/docker-machine
-ENV MACHINE_STORAGE_PATH=/opt/devops-utils/docker-machine
-
 
 WORKDIR /opt/devops-utils
 ENTRYPOINT ["/usr/bin/ssh-agent", "/usr/local/bin/docker-init"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ RUN cd /opt/devops-utils && pip install . && \
 ADD ["https://github.com/docker/machine/releases/download/v0.3.0/docker-machine_linux-amd64", \
      "/usr/local/bin/docker-machine"]
 RUN chmod +x /usr/local/bin/docker-machine
+ENV MACHINE_STORAGE_PATH=/opt/devops-utils/docker-machine
+
 
 WORKDIR /opt/devops-utils
 ENTRYPOINT ["/usr/bin/ssh-agent", "/usr/local/bin/docker-init"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Full documentation can be found on [RTFD](http://devops-utils.rtfd.org/).
  - built in utilities:
    - [Ansible](http://www.ansible.com/)
    - [Fabric](http://www.fabfile.org/)
+   - [docker-machine](http://www.docker.com/)
  - external runner which wraps `docker run` to make it look like the
    utilities are installed on the host
  - extensible startup process allowing derived images to customise

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Features
 
    - Ansible_
    - Fabric_
+   - docker-machine
 
  - external runner which wraps ``docker run`` to make it look like the
    utilities are installed on the host
@@ -22,6 +23,7 @@ Features
 
 .. _Ansible: http://www.ansible.com/
 .. _Fabric: http://www.fabfile.org/
+.. _docker-machine: http://www.docker.com
 
 Contents:
 =========

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -93,6 +93,26 @@ respected.
 Finally, you can pass ``++debug`` option to see how options are
 processed and how arguments to the programs are manipulated.
 
+docker-machine
+--------------
+
+It is possible to run ``docker-machine`` commands within the image.
+When using ``docker-machine``, it is important to pass the ``++dev``
+option, otherwise any changes (like adding new machines) are lost.
+
+``docker-machine`` saves configuration, like keys for servers, and
+in fact the names of what servers are managed in a configuration
+directory, in our image this defaults to ``/opt/app/.docker/machine``.
+
+An example of using ``docker-machine`` is::
+
+    devops-utils ++dev docker-machine upgrade fred
+
+which would execute the ``docker-machine upgrade`` command on host
+``fred``, with /opt/app mounted from current working directory.
+Running the above command in your home directory would pick up any
+previous ``docker-machine`` configuration, and would save anything
+that you change for use at a later date.
 
 .. _usage-extending:
 


### PR DESCRIPTION
PR to add docker-machine to the default image.  This could potentially be useful in an environment where a sysadmin wants to manage a group of docker hosts.
